### PR TITLE
Add `sending` keyword to closures in convenience functions

### DIFF
--- a/Sources/AsyncXPCConnection/NSXPCConnection+Continuations.swift
+++ b/Sources/AsyncXPCConnection/NSXPCConnection+Continuations.swift
@@ -168,7 +168,7 @@ extension NSXPCConnection {
 	public func withValueErrorCompletion<Service, Value: Sendable>(
 		isolation: isolated (any Actor)? = #isolation,
 		function: String = #function,
-		_ body: (Service, @escaping (Value?, Error?) -> Void) -> Void
+		_ body: (Service, sending @escaping (Value?, Error?) -> Void) -> Void
 	) async throws -> Value {
 		try await withContinuation(isolation: isolation, function: function) { service, continuation in
 			body(service) { value, error in
@@ -233,7 +233,7 @@ extension NSXPCConnection {
 	public func withResultCompletion<Service, Value: Sendable>(
 		isolation: isolated (any Actor)? = #isolation,
 		function: String = #function,
-		_ body: (Service, @escaping (Result<Value, Error>) -> Void) -> Void
+		_ body: (Service, sending @escaping (Result<Value, Error>) -> Void) -> Void
 	) async throws -> Value {
 		try await withContinuation(isolation: isolation, function: function) { service, continuation in
 			body(service) { result in
@@ -281,7 +281,7 @@ extension NSXPCConnection {
 	public func withErrorCompletion<Service>(
 		isolation: isolated (any Actor)? = #isolation,
 		function: String = #function,
-		_ body: (Service, @escaping (Error?) -> Void) -> Void
+		_ body: (Service, sending @escaping (Error?) -> Void) -> Void
 	) async throws {
 		try await withContinuation(isolation: isolation, function: function) { (service, continuation: CheckedContinuation<Void, Error>) in
 			body(service) { error in
@@ -333,7 +333,7 @@ extension NSXPCConnection {
 		isolation: isolated (any Actor)? = #isolation,
 		function: String = #function,
 		using decoder: Decoder = JSONDecoder(),
-		_ body: (Service, @escaping (Data?, Error?) -> Void) -> Void
+		_ body: (Service, sending @escaping (Data?, Error?) -> Void) -> Void
 	) async throws -> Value where Decoder.Input == Data {
 		let data: Data = try await withValueErrorCompletion(isolation: isolation, function: function) { service, handler in
 			body(service, handler)

--- a/Sources/AsyncXPCConnection/QueuedRemoteXPCService.swift
+++ b/Sources/AsyncXPCConnection/QueuedRemoteXPCService.swift
@@ -54,7 +54,7 @@ extension QueuedRemoteXPCService {
 
 	public func addResultOperation<Value: Sendable>(
 		barrier: Bool = false,
-		operation: @escaping (Service, @escaping ResultOperationHandler<Value>) -> Void
+		operation: @escaping (Service, sending @escaping ResultOperationHandler<Value>) -> Void
 	) async throws -> Value {
 		let task: Task<Value, Error> = queue.addOperation(priority: nil, barrier: barrier) {
 			let conn = try await provider()
@@ -69,7 +69,7 @@ extension QueuedRemoteXPCService {
 
 	public func addErrorOperation(
 		barrier: Bool = false,
-		operation: @escaping (Service, @escaping ErrorOperationHandler) -> Void
+		operation: @escaping (Service, sending @escaping ErrorOperationHandler) -> Void
 	) async throws {
 		let task: Task<Void, Error> = queue.addOperation(priority: nil, barrier: barrier) {
 			let conn = try await provider()
@@ -84,7 +84,7 @@ extension QueuedRemoteXPCService {
 
 	public func addDiscardingErrorOperation(
 		barrier: Bool = false,
-		operation: @escaping (Service, @escaping ErrorOperationHandler) -> Void
+		operation: @escaping (Service, sending @escaping ErrorOperationHandler) -> Void
 	) {
 		queue.addOperation(priority: nil, barrier: barrier) {
 			let conn = try await provider()
@@ -97,7 +97,7 @@ extension QueuedRemoteXPCService {
 
 	public func addValueErrorOperation<Value: Sendable>(
 		barrier: Bool = false,
-		operation: @escaping (Service, @escaping ValueErrorOperationHandler<Value>) -> Void
+		operation: @escaping (Service, sending @escaping ValueErrorOperationHandler<Value>) -> Void
 	) async throws -> Value {
 		let task: Task<Value, Error> = queue.addOperation(priority: nil, barrier: barrier) {
 			let conn = try await provider()
@@ -113,7 +113,7 @@ extension QueuedRemoteXPCService {
 	public func addDecodingOperation<Value: Sendable & Decodable, Decoder: TopLevelDecoder>(
 		barrier: Bool = false,
 		using decoder: Decoder = JSONDecoder(),
-		operation: @escaping (Service, @escaping ValueErrorOperationHandler<Data>) -> Void
+		operation: @escaping (Service, sending @escaping ValueErrorOperationHandler<Data>) -> Void
 	) async throws -> Value where Decoder.Input == Data {
 		let task: Task<Value, Error> = queue.addOperation(priority: nil, barrier: barrier) {
 			let conn = try await provider()

--- a/Sources/AsyncXPCConnection/RemoteXPCService.swift
+++ b/Sources/AsyncXPCConnection/RemoteXPCService.swift
@@ -100,7 +100,7 @@ extension RemoteXPCService {
 	public func withValueErrorCompletion<Value: Sendable>(
 		isolation: isolated (any Actor)? = #isolation,
 		function: String = #function,
-		_ body: (Service, @escaping (Value?, Error?) -> Void) -> Void
+		_ body: (Service, sending @escaping (Value?, Error?) -> Void) -> Void
 	) async throws -> Value {
 		try await connection.withValueErrorCompletion(isolation: isolation, function: function, body)
 	}
@@ -108,7 +108,7 @@ extension RemoteXPCService {
 	public func withResultCompletion<Value: Sendable>(
 		isolation: isolated (any Actor)? = #isolation,
 		function: String = #function,
-		_ body: (Service, @escaping (Result<Value, Error>) -> Void) -> Void
+		_ body: (Service, sending @escaping (Result<Value, Error>) -> Void) -> Void
 	) async throws -> Value {
 		try await connection.withResultCompletion(isolation: isolation, function: function, body)
 	}
@@ -116,7 +116,7 @@ extension RemoteXPCService {
 	public func withErrorCompletion(
 		isolation: isolated (any Actor)? = #isolation,
 		function: String = #function,
-		_ body: (Service, @escaping (Error?) -> Void) -> Void
+		_ body: (Service, sending @escaping (Error?) -> Void) -> Void
 	) async throws {
 		try await connection.withErrorCompletion(isolation: isolation, function: function, body)
 	}
@@ -125,7 +125,7 @@ extension RemoteXPCService {
 		isolation: isolated (any Actor)? = #isolation,
 		function: String = #function,
 		using decoder: Decoder = JSONDecoder(),
-		_ body: (Service, @escaping (Data?, Error?) -> Void) -> Void
+		_ body: (Service, sending @escaping (Data?, Error?) -> Void) -> Void
 	) async throws -> Value where Decoder.Input == Data {
 		try await connection.withDecodingCompletion(isolation: isolation, function: function, using: decoder, body)
 	}


### PR DESCRIPTION
This functionality was already possible when directly using convenience functions that provide a continuation (`NSXPCConnection.withContinuation(isolation:function:_:)`, for example), but now the other convenience functions support it too!
I have no easy way of testing with Swift < 6 so none of that is changed.